### PR TITLE
do not use deprecated ContainerAwareEventDispatcher

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,7 +5,7 @@
 
     <parameters>
         <parameter key="bazinga.propel_event_dispatcher.registered_classes" type="collection" />
-        <parameter key="bazinga.propel_event_dispatcher.event_dispatcher.class">Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher</parameter>
+        <parameter key="bazinga.propel_event_dispatcher.event_dispatcher.class">Symfony\Component\EventDispatcher\EventDispatcher</parameter>
         <parameter key="bazinga.propel_event_dispatcher.injector.class">Bazinga\Bundle\PropelEventDispatcherBundle\Injector\DispatcherInjector</parameter>
     </parameters>
 

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
         "marcj/propel-eventdispatcher-behavior": "^1.0"
     },
     "require-dev": {
-        "symfony/framework-bundle": "~2.1||~3.0",
-        "symfony/yaml": "~2.1||~3.0"
+        "symfony/framework-bundle": "^3.3",
+        "symfony/yaml": "^3.3"
     },
     "authors": [
         {


### PR DESCRIPTION
With Symfony 3.3 I get this deprecation notice:

> The Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher class is deprecated since version 3.3 and will be removed in 4.0. Use EventDispatcher with closure factories instead.